### PR TITLE
Security review: IAM/SSM policy, sudo hardening, CI, tags, Terraform 1.10 / AWS 6

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -27,7 +27,7 @@ runs:
       run: |
         set -euo pipefail
         python -m pip install --upgrade pip
-        pip install ansible-core ansible-lint yamllint checkov
+        pip install -r requirements-dev.txt
         TFSEC_VERSION=1.28.14
         TFSEC_SHA256=329ae7f67f2f1813ebe08de498719ea7003c75d3ca24bb0b038369062508008e
         curl -sSL "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec_${TFSEC_VERSION}_linux_amd64.tar.gz" -o tfsec.tgz

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -1,0 +1,40 @@
+name: CI setup
+description: Terraform, Terragrunt, TFLint, Python/Ansible tools, pinned tfsec with checksum, shellcheck, jq
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.14.6
+
+    - name: Setup Terragrunt
+      uses: autero1/action-terragrunt@v3
+      with:
+        terragrunt-version: 0.99.4
+
+    - name: Setup TFLint
+      uses: terraform-linters/setup-tflint@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install Python tools, tfsec (pinned + SHA256), apt packages, Ansible collections
+      shell: bash
+      run: |
+        set -euo pipefail
+        python -m pip install --upgrade pip
+        pip install ansible-core ansible-lint yamllint checkov
+        TFSEC_VERSION=1.28.14
+        TFSEC_SHA256=329ae7f67f2f1813ebe08de498719ea7003c75d3ca24bb0b038369062508008e
+        curl -sSL "https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec_${TFSEC_VERSION}_linux_amd64.tar.gz" -o tfsec.tgz
+        echo "${TFSEC_SHA256}  tfsec.tgz" | sha256sum -c -
+        sudo tar -xzf tfsec.tgz -C /usr/local/bin tfsec
+        rm -f tfsec.tgz
+        sudo apt-get update
+        sudo apt-get install -y shellcheck jq bats
+        mkdir -p ansible/collections
+        ansible-galaxy collection install -r ansible/requirements.yml -p ansible/collections

--- a/.github/workflows/aws-plan-optional.yml
+++ b/.github/workflows/aws-plan-optional.yml
@@ -1,0 +1,67 @@
+# Optional Terragrunt plan against the bundled example live config (real AWS + remote state).
+# This workflow is manual-only and is designed to succeed when AWS/OIDC is not configured.
+#
+# To actually run plans: set repository secret AWS_PLAN_TEST_ROLE_ARN and configure GitHub as an
+# OIDC identity provider in IAM for that role (trust policy).
+name: Optional AWS plan (manual)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  terragrunt-plan-example:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: CI setup
+        uses: ./.github/actions/ci-setup
+
+      # Skip all AWS steps when the secret is missing — workflow stays green (no OIDC required).
+      - name: Check for AWS plan configuration
+        id: gate
+        env:
+          AWS_PLAN_TEST_ROLE_ARN: ${{ secrets.AWS_PLAN_TEST_ROLE_ARN }}
+        run: |
+          if [ -z "${AWS_PLAN_TEST_ROLE_ARN}" ]; then
+            echo "run_aws_plan=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_aws_plan=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        id: aws
+        if: steps.gate.outputs.run_aws_plan == 'true'
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_PLAN_TEST_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Terragrunt init and plan (dev / east / us-east-1)
+        if: steps.gate.outputs.run_aws_plan == 'true' && steps.aws.outcome == 'success'
+        env:
+          TG_DOWNLOAD_DIR: ${{ github.workspace }}/.cache/terragrunt
+        run: |
+          set -euo pipefail
+          base="examples/live/dev/east/us-east-1"
+          for name in bootstrap-state observability vpc-endpoints jump-hosts; do
+            echo "=== $base/$name ==="
+            terragrunt --working-dir "$base/$name" init -input=false -no-color
+            terragrunt --working-dir "$base/$name" plan -input=false -no-color
+          done
+
+      - name: Notice — optional plan not configured
+        if: steps.gate.outputs.run_aws_plan != 'true'
+        run: |
+          echo "::notice::AWS_PLAN_TEST_ROLE_ARN is not set — skipped Terragrunt plan. This workflow is optional; default CI does not use OIDC or this secret."
+
+      - name: Notice — AWS login failed (still green)
+        if: steps.gate.outputs.run_aws_plan == 'true' && steps.aws.outcome != 'success'
+        run: |
+          echo "::notice::AWS OIDC/login failed (trust policy, role ARN, or permissions). Job left successful; fix IAM/OIDC to run Terragrunt plans."

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,34 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.14.6
-
-      - name: Setup Terragrunt
-        uses: autero1/action-terragrunt@v3
-        with:
-          terragrunt-version: 0.99.4
-
-      - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install ansible-core ansible-lint yamllint checkov
-          curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
-          sudo apt-get update
-          sudo apt-get install -y shellcheck jq
-          ansible-galaxy collection install -r ansible/requirements.yml
+      - name: CI setup
+        uses: ./.github/actions/ci-setup
 
       - name: Full check (static + validation)
         env:
           SKIP_PREFLIGHT: "true"
         run: make check
+
+      - name: Policy, contracts, shell, and Ansible tests
+        run: make test

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,32 +14,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_version: 1.14.6
-
-      - name: Setup Terragrunt
-        uses: autero1/action-terragrunt@v3
-        with:
-          terragrunt-version: 0.99.4
-
-      - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v4
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install tooling
-        run: |
-          python -m pip install --upgrade pip
-          pip install ansible-core ansible-lint yamllint checkov
-          curl -s https://raw.githubusercontent.com/aquasecurity/tfsec/master/scripts/install_linux.sh | bash
-          sudo apt-get update
-          sudo apt-get install -y shellcheck jq
-          ansible-galaxy collection install -r ansible/requirements.yml
+      - name: CI setup
+        uses: ./.github/actions/ci-setup
 
       - name: Format check
         run: make fmt-check

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ ansible/inventory/generated-*.yml
 .ansible/
 ansible/collections/ansible_collections/
 
+.claude/
+local_code_review.md

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ ansible/collections/ansible_collections/
 
 .claude/
 local_code_review.md
+
+.env
+.envrc

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,7 +4,6 @@ terragrunt 0.99.4
 
 # Runtime and cloud CLI
 python 3.11.11
-awscli 2.17.61
 
 # Static analysis/security tooling used in make/CI
 tflint 0.55.1
@@ -15,4 +14,4 @@ jq 1.7.1
 shellcheck 0.10.0
 
 # AWS CLI
-aws latest
+aws 2.34.22

--- a/.tool-versions
+++ b/.tool-versions
@@ -13,3 +13,6 @@ tfsec 1.28.14
 # Script and shell utilities used in make/scripts
 jq 1.7.1
 shellcheck 0.10.0
+
+# AWS CLI
+aws latest

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ANSIBLE_LINT_PATHS ?= ansible/playbooks ansible/roles ansible/group_vars ansible
 YAMLLINT_PATHS ?= ansible/playbooks ansible/roles ansible/group_vars ansible/requirements.yml ansible/vars-schema.example.yml
 TG_DOWNLOAD_DIR ?= $(abspath .cache/terragrunt)
 
-.PHONY: help install-tools fmt fmt-check lint validate check plan-example apply-example configure-example destroy-example
+.PHONY: help install-tools fmt fmt-check lint validate check shell-test policy-test contract-test ansible-test test plan-example apply-example apply-example-auto configure-example destroy-example destroy-example-auto
 
 help:
 	@echo "Targets:"
@@ -21,10 +21,17 @@ help:
 	@echo "  lint          - Run static linters and policy checks"
 	@echo "  validate      - Run terraform, terragrunt, and ansible validation"
 	@echo "  check         - Run fmt-check + lint + validate (+ optional preflight)"
+	@echo "  shell-test    - Bats tests for scripts (requires bats-core on PATH)"
+	@echo "  policy-test   - Validate IAM policy template invariants (jq)"
+	@echo "  contract-test - Repo contract checks (log group naming, tool pins, deprecated vars)"
+	@echo "  ansible-test  - Localhost Ansible smoke + negative test for user_accounts"
+	@echo "  test          - policy-test + contract-test + shell-test + ansible-test"
 	@echo "  plan-example  - Run orchestrator plan against example live config"
-	@echo "  apply-example - Run orchestrator apply against example live config"
+	@echo "  apply-example - Run orchestrator apply (interactive Terraform; confirm each apply)"
+	@echo "  apply-example-auto - Same as apply-example with --auto-approve (CI/non-interactive)"
 	@echo "  configure-example - Run Ansible-only host configuration against example live config"
-	@echo "  destroy-example - Run orchestrator destroy against example live config"
+	@echo "  destroy-example - Run orchestrator destroy (interactive Terraform)"
+	@echo "  destroy-example-auto - Same as destroy-example with --auto-approve"
 
 install-tools:
 	@if command -v mise >/dev/null 2>&1; then \
@@ -33,8 +40,10 @@ install-tools:
 	else \
 		echo "mise not found; skipping .tool-versions installation"; \
 	fi
-	python -m pip install --upgrade pip
-	python -m pip install -r requirements-dev.txt
+	@py=python; command -v $$py >/dev/null 2>&1 || py=python3; \
+	command -v $$py >/dev/null 2>&1 || { echo "python or python3 required for install-tools" >&2; exit 1; }; \
+	PIP_BREAK_SYSTEM_PACKAGES=1 $$py -m pip install --upgrade pip; \
+	PIP_BREAK_SYSTEM_PACKAGES=1 $$py -m pip install -r requirements-dev.txt
 	@mkdir -p .ansible/tmp .ansible/home ansible/collections "$(TG_DOWNLOAD_DIR)"
 	HOME="$(PWD)/.ansible/home" ANSIBLE_LOCAL_TEMP="$(PWD)/.ansible/tmp" ANSIBLE_CONFIG="$(PWD)/ansible.cfg" \
 		ansible-galaxy collection install -r ansible/requirements.yml -p ansible/collections
@@ -83,14 +92,45 @@ check: install-tools fmt-check lint validate
 			--expected-log-group "$${EXPECTED_LOG_GROUP:?EXPECTED_LOG_GROUP is required when SKIP_PREFLIGHT is false}"; \
 	fi
 
+shell-test:
+	@command -v bats >/dev/null 2>&1 || { echo "bats not found; install bats-core (e.g. apt install bats or brew install bats-core)" >&2; exit 1; }
+	bats tests/shell/*.bats
+
+policy-test:
+	./tests/policy/validate_ssm_policy.sh policy-templates/ssm-access-example.json
+
+contract-test:
+	./tests/contracts/check_log_group.sh
+	./tests/contracts/check_tool_pins.sh
+	./tests/contracts/check_deprecated_vars.sh
+
+ansible-test: install-tools
+	@mkdir -p .ansible/tmp .ansible/home
+	HOME="$(PWD)/.ansible/home" ANSIBLE_LOCAL_TEMP="$(PWD)/.ansible/tmp" ANSIBLE_CONFIG="$(PWD)/ansible.cfg" \
+		ansible-playbook -i tests/ansible/inventory/localhost.yml tests/ansible/user_accounts_smoke.yml
+	@set +e; \
+	HOME="$(PWD)/.ansible/home" ANSIBLE_LOCAL_TEMP="$(PWD)/.ansible/tmp" ANSIBLE_CONFIG="$(PWD)/ansible.cfg" \
+		ansible-playbook -i tests/ansible/inventory/localhost.yml tests/ansible/user_accounts_negative.yml; \
+	neg=$$?; \
+	set -e; \
+	if [[ "$$neg" -eq 0 ]]; then echo "ansible-test: expected user_accounts_negative.yml to fail" >&2; exit 1; fi
+
+test: policy-test contract-test shell-test ansible-test
+
 plan-example:
 	./scripts/orchestrate.sh plan --live-dir "$(LIVE_DIR)" --env "$(ENV)" --subenv "$(SUBENV)" --region "$(REGION)" --users-vars "$(USERS_VARS)"
 
 apply-example:
 	./scripts/orchestrate.sh apply --live-dir "$(LIVE_DIR)" --env "$(ENV)" --subenv "$(SUBENV)" --region "$(REGION)" --users-vars "$(USERS_VARS)"
 
+apply-example-auto:
+	./scripts/orchestrate.sh apply --live-dir "$(LIVE_DIR)" --env "$(ENV)" --subenv "$(SUBENV)" --region "$(REGION)" --users-vars "$(USERS_VARS)" --auto-approve
+
 configure-example:
 	./scripts/orchestrate.sh configure --live-dir "$(LIVE_DIR)" --env "$(ENV)" --subenv "$(SUBENV)" --region "$(REGION)" --users-vars "$(USERS_VARS)"
 
 destroy-example:
 	./scripts/orchestrate.sh destroy --live-dir "$(LIVE_DIR)" --env "$(ENV)" --subenv "$(SUBENV)" --region "$(REGION)" --users-vars "$(USERS_VARS)"
+
+destroy-example-auto:
+	./scripts/orchestrate.sh destroy --live-dir "$(LIVE_DIR)" --env "$(ENV)" --subenv "$(SUBENV)" --region "$(REGION)" --users-vars "$(USERS_VARS)" --auto-approve

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Turn-key solution for deploying and managing private AWS jump hosts through AWS 
 
 ## Example Orchestration
 
+Run `plan` from the repository root (paths to scripts and generated inventory are rooted automatically):
+
 ```bash
 ./scripts/orchestrate.sh plan \
   --live-dir ./examples/live \
@@ -43,3 +45,5 @@ Turn-key solution for deploying and managing private AWS jump hosts through AWS 
   --region us-east-1 \
   --users-vars ./ansible/vars-schema.example.yml
 ```
+
+`apply` and `destroy` run Terraform interactively by default. Add `--auto-approve` for non-interactive use, or use `make apply-example-auto` / `make destroy-example-auto`.

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 inventory = ansible/inventory/hosts.yml
+# SSH host keys are not used by the aws_ssm connection plugin; this avoids misleading verify warnings.
 host_key_checking = False
 retry_files_enabled = False
 stdout_callback = yaml

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -13,9 +13,10 @@ home_volume_device_candidates:
 home_volume_mount_path: /home
 home_volume_fstype: ext4
 
-ops_sudo_commands:
+user_accounts_ops_sudo_commands:
   - /usr/bin/systemctl --no-pager status *
   - /usr/bin/systemctl --no-pager is-active *
   - /usr/bin/systemctl --no-pager is-failed *
   - /usr/bin/systemctl --no-pager is-enabled *
-  - /usr/bin/journalctl --no-pager
+  - /usr/bin/journalctl --no-pager -u *
+  - /usr/bin/journalctl --no-pager --unit=*

--- a/ansible/playbooks/decommission.yml
+++ b/ansible/playbooks/decommission.yml
@@ -14,4 +14,3 @@
         user_accounts_users: "{{ users }}"
         user_accounts_managed_user_uid_min: "{{ managed_user_uid_min | default(1000) }}"
         user_accounts_managed_user_exclusions: "{{ managed_user_exclusions | default(['ec2-user', 'ssm-user', 'nobody']) }}"
-        user_accounts_ops_sudo_commands: "{{ ops_sudo_commands | default(['/usr/bin/systemctl', '/usr/bin/journalctl']) }}"

--- a/ansible/playbooks/jump_hosts.yml
+++ b/ansible/playbooks/jump_hosts.yml
@@ -15,4 +15,3 @@
         user_accounts_users: "{{ users | default([]) }}"
         user_accounts_managed_user_uid_min: "{{ managed_user_uid_min | default(1000) }}"
         user_accounts_managed_user_exclusions: "{{ managed_user_exclusions | default(['ec2-user', 'ssm-user', 'nobody']) }}"
-        user_accounts_ops_sudo_commands: "{{ ops_sudo_commands | default([]) }}"

--- a/ansible/roles/user_accounts/defaults/main.yml
+++ b/ansible/roles/user_accounts/defaults/main.yml
@@ -1,13 +1,20 @@
 ---
+# When false, admin sudo_profile uses user_accounts_admin_sudo_commands (Cmnd_Alias) instead of NOPASSWD:ALL.
+# Set to false and populate the command list when tightening admin access (see vars-schema.example.yml).
+user_accounts_admin_use_unrestricted_sudo: true
+user_accounts_admin_sudo_commands: []
+
 user_accounts_users: []
 user_accounts_managed_user_uid_min: 1000
 user_accounts_managed_user_exclusions:
   - ec2-user
   - ssm-user
   - nobody
+# systemctl lines use a single trailing sudoers glob for the unit name; avoid adding broader wildcards.
 user_accounts_ops_sudo_commands:
   - /usr/bin/systemctl --no-pager status *
   - /usr/bin/systemctl --no-pager is-active *
   - /usr/bin/systemctl --no-pager is-failed *
   - /usr/bin/systemctl --no-pager is-enabled *
-  - /usr/bin/journalctl --no-pager
+  - /usr/bin/journalctl --no-pager -u *
+  - /usr/bin/journalctl --no-pager --unit=*

--- a/ansible/roles/user_accounts/tasks/main.yml
+++ b/ansible/roles/user_accounts/tasks/main.yml
@@ -16,6 +16,13 @@
   ansible.builtin.getent:
     database: passwd
 
+# SSM may create ssm-user; it stays out of reconciliation but should not allow password auth.
+- name: Lock password for local ssm-user account
+  ansible.builtin.user:
+    name: ssm-user
+    password_lock: true
+  when: "'ssm-user' in ansible_facts.getent_passwd"
+
 - name: Build declared user list
   ansible.builtin.set_fact:
     user_accounts_declared_users: "{{ user_accounts_users | map(attribute='username') | list }}"
@@ -40,6 +47,17 @@
   ansible.builtin.group:
     name: wheel
     state: present
+
+- name: Validate restricted admin sudo has a non-empty command list
+  ansible.builtin.assert:
+    that:
+      - user_accounts_admin_sudo_commands | length > 0
+    fail_msg: >-
+      user_accounts_admin_use_unrestricted_sudo is false but user_accounts_admin_sudo_commands is empty.
+      Define allowed commands (same pattern as ops) before using restricted admin.
+  when:
+    - not user_accounts_admin_use_unrestricted_sudo | default(true)
+    - (user_accounts_users | selectattr('sudo_profile', 'equalto', 'admin') | rejectattr('state', 'equalto', 'absent') | list | length) > 0
 
 - name: Ensure declared users exist with locked passwords
   ansible.builtin.user:

--- a/ansible/roles/user_accounts/templates/sudoers.j2
+++ b/ansible/roles/user_accounts/templates/sudoers.j2
@@ -1,5 +1,11 @@
 {% if item.sudo_profile == 'admin' -%}
+{% if user_accounts_admin_use_unrestricted_sudo | default(true) -%}
 {{ item.username }} ALL=(ALL) NOPASSWD:ALL
+{% else -%}
+{% set admin_alias = 'ADMIN_CMDS_' ~ (item.username | upper | regex_replace('[^A-Z0-9_]', '_')) -%}
+Cmnd_Alias {{ admin_alias }} = {{ user_accounts_admin_sudo_commands | join(', ') }}
+{{ item.username }} ALL=(ALL) NOPASSWD:{{ admin_alias }}
+{% endif -%}
 {% elif item.sudo_profile == 'ops' -%}
 {% set ops_alias = 'OPS_CMDS_' ~ (item.username | upper | regex_replace('[^A-Z0-9_]', '_')) -%}
 Cmnd_Alias {{ ops_alias }} = {{ user_accounts_ops_sudo_commands | join(', ') }}

--- a/ansible/vars-schema.example.yml
+++ b/ansible/vars-schema.example.yml
@@ -1,5 +1,9 @@
 ---
 # Example external user declaration schema.
+#
+# WARNING — sudo_profile: admin uses unrestricted passwordless root (NOPASSWD:ALL) by default.
+# To migrate later, set role vars user_accounts_admin_use_unrestricted_sudo: false and
+# user_accounts_admin_sudo_commands: [ '/usr/bin/somecmd', ... ] (see ansible/roles/user_accounts/defaults/main.yml).
 users:
   - username: jumpops
     groups:
@@ -9,6 +13,7 @@ users:
     shell: /bin/bash
     home: /home/jumpops
 
+  # Example only: admin = full root on the bastion. Prefer ops profile + break-glass admin only if required.
   - username: platform-admin
     groups:
       - platform

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ The resulting platform provisions private jump hosts reachable through AWS Sessi
 
 - `modules/terraform/jump_hosts`: EC2 hosts, instance profile, optional default SG, and persistent `/home` EBS volumes.
 - `modules/terraform/vpc_endpoints_ssm`: shared interface endpoints for private SSM and CloudWatch connectivity.
-- `modules/terraform/observability`: CloudWatch log group and optional KMS key.
+- `modules/terraform/observability`: CloudWatch log group and optional KMS key; optional metric filter and alarm hooks (disabled by default) for future SNS paging.
 - `modules/terraform/remote_state_s3`: encrypted versioned S3 state bucket.
 
 ### Terragrunt
@@ -61,3 +61,7 @@ The resulting platform provisions private jump hosts reachable through AWS Sessi
 - Backend state locking uses the native S3 lockfile (`use_lockfile = true`, requires Terraform ≥ 1.10). No DynamoDB table is required.
 - Destroy defaults to preserving bootstrap state bucket unless `--destroy-state` is explicitly passed.
 - Production environment inputs are expected to live outside this repository.
+
+### Single-AZ examples (accepted tradeoff)
+
+Reference `examples/live` stacks provision **one** jump host in **one** availability zone. That is an intentional **single point of failure** for cost and simplicity: if the instance, AZ, or volume has an outage, SSM access via that host is unavailable until recovery or replacement. For resilience, define multiple entries in the `hosts` map across subnets in different AZs; the Terraform module supports it, but the examples do not demonstrate HA.

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -22,6 +22,38 @@ Create a separate repo with:
 
 Then reference module and root paths from this repository.
 
+## Global AWS tags (cascade)
+
+`terragrunt/root.hcl` builds `common_tags` and applies them in two ways:
+
+1. **Provider `default_tags`** (generated `provider_generated.tf`) — taggable AWS resources created in these stacks receive these tags even when a module does not set `tags`.
+2. **Module inputs** — stacks pass `include.root.locals.common_tags` (or merge with it) so modules that explicitly merge tags keep the same baseline keys.
+
+Built-in keys today: `Project`, `Environment`, `SubEnvironment`, `Region`, `ManagedBy`.
+
+To add your own tags once and have them flow everywhere, define optional `extra_tags` maps in your live hierarchy files (same merge as `common_tags`; duplicate keys are overridden by the more specific file):
+
+| File           | Typical use                                      |
+|----------------|--------------------------------------------------|
+| `account.hcl`  | Account-wide tags (`CostCenter`, `Owner`, …)     |
+| `env.hcl`      | Environment-wide tags (`DataClassification`, …) |
+| `subenv.hcl`   | Sub-environment or segment tags                  |
+
+Example in `account.hcl`:
+
+```hcl
+locals {
+  account_id       = "123456789012"
+  assume_role_name = "OrganizationAccountAccessRole"
+  state_bucket     = "my-org-jump-host-state"
+  extra_tags = {
+    CostCenter = "platform-engineering"
+  }
+}
+```
+
+Omit `extra_tags` in a file if you do not need that layer.
+
 ## Minimum Inputs Per Region
 
 - `vpc_id`

--- a/docs/consumer-guide.md
+++ b/docs/consumer-guide.md
@@ -36,7 +36,7 @@ From this repository root:
 
 1. `./scripts/orchestrate.sh init --live-dir <external-live-dir> --env <env> --subenv <subenv> --region <region> --users-vars <users-file>`
 2. `./scripts/orchestrate.sh plan --live-dir ...`
-3. `./scripts/orchestrate.sh apply --live-dir ...`
+3. `./scripts/orchestrate.sh apply --live-dir ...` (Terraform prompts for confirmation on each stack unless you pass `--auto-approve`)
 
 For host configuration changes without Terraform execution (for example user add/remove only):
 
@@ -44,8 +44,10 @@ For host configuration changes without Terraform execution (for example user add
 
 For teardown:
 
-- `./scripts/orchestrate.sh destroy --live-dir ...`
+- `./scripts/orchestrate.sh destroy --live-dir ...` (interactive by default; use `--auto-approve` only for automation)
 - Add `--destroy-state` only if removing backend state bucket intentionally.
+
+Non-interactive CI or scripted applies should append `--auto-approve` to both `apply` and `destroy`. The Makefile provides `apply-example-auto` and `destroy-example-auto` for the bundled examples.
 
 ## User Schema Contract
 
@@ -57,6 +59,8 @@ External vars must follow:
 - optional `state`, `shell`, `home`
 
 The `user_accounts` role is authoritative for managed users above the UID threshold and disables undeclared users (excluding configured system account allowlist).
+
+To customize the `ops` sudo allowlist, set `user_accounts_ops_sudo_commands` in group vars or extra-vars (this repository’s `ansible/group_vars/all.yml` is the default). If you previously used `ops_sudo_commands` in an external inputs repo, rename that key to match the role variable.
 
 ## Local and CI Validation
 

--- a/docs/security-user-prerequisites.md
+++ b/docs/security-user-prerequisites.md
@@ -35,12 +35,16 @@ Starter template in this repo:
 
 ## Required Access Scoping (ABAC)
 
-The role should be scoped to jump hosts using instance tags:
+The role should be scoped to jump hosts using instance tags on **StartSession**:
 
 - `ssm:resourceTag/JumpHost == "true"`
-- `ssm:resourceTag/AccessProfile == ${aws:PrincipalTag/AccessProfile}`
+- `ssm:resourceTag/AccessProfile == ${aws:PrincipalTag/AccessProfile}` using **`StringEquals`** (see `policy-templates/ssm-access-example.json`)
 
-This requires the principal to carry an `AccessProfile` tag (role tag or session tag, per your federation model).
+The principal must carry an `AccessProfile` tag with **exactly one** value (role tag or session tag, per your federation model). Do not use `ForAnyValue:StringEquals` for this pair; it can match unintended profiles when multiple tag values appear in the request context.
+
+**ResumeSession / TerminateSession** in the example policy are limited to session ARNs `.../session/${aws:username}-*`. The `aws:username` value depends on identity type: for an IAM user it is the user name; for `sts:AssumeRole` it is typically the **role session name** (often the federated user identifier). Confirm the resulting session ID prefix in your environment with a test session.
+
+**StartSession** remains constrained by instance tags; operators cannot start sessions on instances whose `AccessProfile` tag does not match their principal tag.
 
 ## Required IAM-to-Linux User Mapping
 

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -4,7 +4,8 @@ This repository follows major-version compatibility ranges (not strict patch pin
 
 ## Supported Ranges
 
-- Terraform: >= 1.10 (required for native S3 state locking via `use_lockfile = true`; no strict patch pinning above this floor)
+- Terraform: ~> 1.10 (required for native S3 state locking via `use_lockfile = true`; allows any 1.x that satisfies the constraint)
+- AWS provider (modules): ~> 6.0
 - Terragrunt: 0.55.x - 0.68.x
 - Ansible Core: >=2.15,<2.18
 - Python: 3.10+

--- a/docs/toolchain.md
+++ b/docs/toolchain.md
@@ -6,7 +6,7 @@ This repository follows major-version compatibility ranges (not strict patch pin
 
 - Terraform: ~> 1.10 (required for native S3 state locking via `use_lockfile = true`; allows any 1.x that satisfies the constraint)
 - AWS provider (modules): ~> 6.0
-- Terragrunt: 0.55.x - 0.68.x
+- Terragrunt: 0.99.x (pinned in `.tool-versions` and `.github/actions/ci-setup`; same minor as local/CI)
 - Ansible Core: >=2.15,<2.18
 - Python: 3.10+
 

--- a/examples/live/README.md
+++ b/examples/live/README.md
@@ -21,4 +21,4 @@ This directory contains reference-only Terragrunt configurations.
 
 1. Copy this structure to an external repo.
 2. Update `account.hcl`, `region.hcl`, and stack inputs.
-3. Run `scripts/orchestrate.sh` from this repo with `--live-dir` pointing to external config.
+3. Run `scripts/orchestrate.sh` from this repository root with `--live-dir` pointing at your live config (the script resolves paths from the repo root). `apply` and `destroy` are interactive unless you pass `--auto-approve`.

--- a/examples/live/dev/account.hcl
+++ b/examples/live/dev/account.hcl
@@ -2,4 +2,6 @@ locals {
   account_id       = "111111111111"
   assume_role_name = "OrganizationAccountAccessRole"
   state_bucket     = "aws-jump-host-dev-state"
+  # Optional: merged into provider default_tags and all module tag maps (see docs/consumer-guide.md).
+  # extra_tags = { CostCenter = "example" }
 }

--- a/modules/terraform/jump_hosts/main.tf
+++ b/modules/terraform/jump_hosts/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = "~> 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/terraform/observability/main.tf
+++ b/modules/terraform/observability/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = "~> 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "kms" {
 
     principals {
       type        = "Service"
-      identifiers = ["logs.${data.aws_region.current.name}.amazonaws.com"]
+      identifiers = ["logs.${data.aws_region.current.id}.amazonaws.com"]
     }
 
     actions = [

--- a/modules/terraform/observability/main.tf
+++ b/modules/terraform/observability/main.tf
@@ -78,3 +78,41 @@ resource "aws_cloudwatch_log_group" "session" {
   kms_key_id        = local.effective_kms_key_arn
   tags              = var.tags
 }
+
+# Alerting hooks (optional): v1 deployments typically only ship logs to this group. When you are ready to page
+# on activity, set enable_session_log_metric_filters and session_log_alarm_actions. Further ideas: EventBridge
+# rules on CloudTrail ssm:StartSession, metric filters for failed logins, or composite alarms for business hours.
+locals {
+  session_hook_suffix = replace(var.log_group_name, "/", "-")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "session_sudo_hook" {
+  count = var.enable_session_log_metric_filters ? 1 : 0
+
+  name           = "${local.session_hook_suffix}-sudo-hook"
+  log_group_name = aws_cloudwatch_log_group.session.name
+  pattern        = var.session_log_sudo_metric_filter_pattern
+
+  metric_transformation {
+    name      = "JumpHostSessionSudoMentions"
+    namespace = "JumpHost/SessionLogs"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "session_sudo_hook" {
+  count = var.enable_session_log_metric_filters ? 1 : 0
+
+  alarm_name          = "${local.session_hook_suffix}-sudo-hook"
+  alarm_description   = "Starter hook: sudo-like substrings in session logs. Tune pattern; add SNS via session_log_alarm_actions."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "JumpHostSessionSudoMentions"
+  namespace           = "JumpHost/SessionLogs"
+  period              = 300
+  statistic           = "Sum"
+  threshold           = 1
+  treat_missing_data  = "notBreaching"
+  alarm_actions       = var.session_log_alarm_actions
+  tags                = var.tags
+}

--- a/modules/terraform/observability/outputs.tf
+++ b/modules/terraform/observability/outputs.tf
@@ -14,6 +14,6 @@ output "kms_key_arn" {
 }
 
 output "session_sudo_metric_alarm_arn" {
-  description = "ARN of the optional session log sudo-hook alarm (empty when enable_session_log_metric_filters is false)."
+  description = "ARN of the optional session log sudo-hook alarm (null when enable_session_log_metric_filters is false)."
   value       = try(aws_cloudwatch_metric_alarm.session_sudo_hook[0].arn, null)
 }

--- a/modules/terraform/observability/outputs.tf
+++ b/modules/terraform/observability/outputs.tf
@@ -12,3 +12,8 @@ output "kms_key_arn" {
   description = "KMS key ARN used by the log group, either existing or created."
   value       = local.effective_kms_key_arn
 }
+
+output "session_sudo_metric_alarm_arn" {
+  description = "ARN of the optional session log sudo-hook alarm (empty when enable_session_log_metric_filters is false)."
+  value       = try(aws_cloudwatch_metric_alarm.session_sudo_hook[0].arn, null)
+}

--- a/modules/terraform/observability/variables.tf
+++ b/modules/terraform/observability/variables.tf
@@ -32,3 +32,24 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_session_log_metric_filters" {
+  description = <<-EOT
+    When true, create a starter CloudWatch Logs metric filter and alarm on the session log group.
+    Defaults to false: initial deployments rely on log delivery only; enable when you add SNS or other alarm_actions.
+  EOT
+  type        = bool
+  default     = false
+}
+
+variable "session_log_alarm_actions" {
+  description = "Alarm action ARNs (typically SNS topics) when the session log metric alarm fires. May be empty for a silent hook."
+  type        = list(string)
+  default     = []
+}
+
+variable "session_log_sudo_metric_filter_pattern" {
+  description = "Logs metric filter pattern for the starter hook (tune to match SSM session transcript format)."
+  type        = string
+  default     = "?sudo"
+}

--- a/modules/terraform/remote_state_s3/main.tf
+++ b/modules/terraform/remote_state_s3/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = "~> 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/modules/terraform/vpc_endpoints_ssm/main.tf
+++ b/modules/terraform/vpc_endpoints_ssm/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = "~> 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = "~> 6.0"
     }
   }
 }
@@ -22,7 +22,7 @@ resource "aws_vpc_endpoint" "interface" {
   for_each = local.endpoint_services
 
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.${each.key}"
+  service_name        = "com.amazonaws.${data.aws_region.current.id}.${each.key}"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.subnet_ids
   security_group_ids  = var.security_group_ids

--- a/policy-templates/README.md
+++ b/policy-templates/README.md
@@ -1,0 +1,9 @@
+# IAM policy templates
+
+## `ssm-access-example.json`
+
+- **AccessProfile:** Use `StringEquals` (not `ForAnyValue:StringEquals`) so the principal’s `AccessProfile` tag must match the instance tag as a single value. Principals should carry **exactly one** `AccessProfile` tag value; multi-value tag sets in some federation setups can unintentionally broaden access with `ForAnyValue`.
+- **StartSession** is allowed only on EC2 and managed-instance ARNs with `JumpHost` and `AccessProfile` tag conditions.
+- **ResumeSession** and **TerminateSession** are allowed only on session ARNs matching `arn:aws:ssm:*:*:session/${aws:username}-*`. Session resources do not use the same `ssm:resourceTag/*` condition keys as instances; gating for new sessions remains on **StartSession**.
+
+Validate changes in the IAM policy simulator for your identity type (IAM user vs assumed role vs SAML/OIDC).

--- a/policy-templates/ssm-access-example.json
+++ b/policy-templates/ssm-access-example.json
@@ -4,26 +4,26 @@
     {
       "Sid": "AllowStartSessionOnTaggedJumpHosts",
       "Effect": "Allow",
-      "Action": [
-        "ssm:StartSession",
-        "ssm:ResumeSession",
-        "ssm:TerminateSession"
-      ],
+      "Action": "ssm:StartSession",
       "Resource": [
         "arn:aws:ec2:*:*:instance/*",
-        "arn:aws:ssm:*:*:managed-instance/*",
-        "arn:aws:ssm:*:*:session/${aws:username}-*"
+        "arn:aws:ssm:*:*:managed-instance/*"
       ],
       "Condition": {
         "StringEquals": {
-          "ssm:resourceTag/JumpHost": "true"
-        },
-        "ForAnyValue:StringEquals": {
-          "ssm:resourceTag/AccessProfile": [
-            "${aws:PrincipalTag/AccessProfile}"
-          ]
+          "ssm:resourceTag/JumpHost": "true",
+          "ssm:resourceTag/AccessProfile": "${aws:PrincipalTag/AccessProfile}"
         }
       }
+    },
+    {
+      "Sid": "AllowResumeTerminateOwnSessions",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:ResumeSession",
+        "ssm:TerminateSession"
+      ],
+      "Resource": "arn:aws:ssm:*:*:session/${aws:username}-*"
     },
     {
       "Sid": "AllowSessionDocumentUsage",

--- a/scripts/orchestrate.sh
+++ b/scripts/orchestrate.sh
@@ -8,11 +8,15 @@ TG_DOWNLOAD_DIR="${TG_DOWNLOAD_DIR:-${REPO_ROOT}/.cache/terragrunt}"
 usage() {
   cat <<USAGE
 Usage:
-  $0 <init|plan|apply|configure|check|destroy> --live-dir <path> --env <env> --subenv <subenv> --region <region> [--users-vars <path>] [--destroy-state]
+  $0 <init|plan|apply|configure|check|destroy> --live-dir <path> --env <env> --subenv <subenv> --region <region> [--users-vars <path>] [--destroy-state] [--auto-approve]
+
+  apply and destroy run Terraform interactively by default (no -auto-approve). Pass --auto-approve for
+  non-interactive runs (CI/automation).
 
 Examples:
   $0 init --live-dir ./examples/live --env dev --subenv east --region us-east-1 --users-vars ./ansible/vars-schema.example.yml
   $0 plan --live-dir ./examples/live --env dev --subenv east --region us-east-1 --users-vars /path/to/users.yml
+  $0 apply --live-dir ./examples/live --env dev --subenv east --region us-east-1 --users-vars /path/to/users.yml --auto-approve
   $0 configure --live-dir ./examples/live --env dev --subenv east --region us-east-1 --users-vars /path/to/users.yml
 USAGE
 }
@@ -30,6 +34,24 @@ run_tg() {
   TG_DOWNLOAD_DIR="$TG_DOWNLOAD_DIR" terragrunt --working-dir "$stack_dir" "$@"
 }
 
+run_tg_apply() {
+  local stack_dir="$1"
+  if [[ "$auto_approve" == "true" ]]; then
+    run_tg "$stack_dir" apply -auto-approve
+  else
+    run_tg "$stack_dir" apply
+  fi
+}
+
+run_tg_destroy() {
+  local stack_dir="$1"
+  if [[ "$auto_approve" == "true" ]]; then
+    run_tg "$stack_dir" destroy -auto-approve
+  else
+    run_tg "$stack_dir" destroy
+  fi
+}
+
 if [[ $# -lt 1 ]]; then
   usage
   exit 1
@@ -44,6 +66,7 @@ subenv_name=""
 aws_region=""
 users_vars=""
 destroy_state="false"
+auto_approve="false"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -71,6 +94,10 @@ while [[ $# -gt 0 ]]; do
       destroy_state="true"
       shift
       ;;
+    --auto-approve)
+      auto_approve="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -93,7 +120,7 @@ bootstrap_dir="$region_dir/bootstrap-state"
 observability_dir="$region_dir/observability"
 endpoints_dir="$region_dir/vpc-endpoints"
 jump_hosts_dir="$region_dir/jump-hosts"
-inventory_path="ansible/inventory/generated-${env_name}-${subenv_name}-${aws_region}.yml"
+inventory_path="${REPO_ROOT}/ansible/inventory/generated-${env_name}-${subenv_name}-${aws_region}.yml"
 expected_log_group="/aws/ssm/jump-host/${env_name}/${subenv_name}/${aws_region}"
 
 for dir in "$region_dir" "$bootstrap_dir" "$observability_dir" "$endpoints_dir" "$jump_hosts_dir"; do
@@ -112,7 +139,7 @@ run_preflight() {
     return 0
   fi
 
-  local cmd=(scripts/preflight_ssm_compliance.sh --region "$aws_region" --expected-log-group "$expected_log_group")
+  local cmd=("${SCRIPT_DIR}/preflight_ssm_compliance.sh" --region "$aws_region" --expected-log-group "$expected_log_group")
   "${cmd[@]}"
 }
 
@@ -125,7 +152,7 @@ run_ansible() {
   require_cmd ansible-playbook
   require_cmd jq
 
-  scripts/render_inventory.sh --terragrunt-dir "$jump_hosts_dir" --output "$inventory_path"
+  "${SCRIPT_DIR}/render_inventory.sh" --terragrunt-dir "$jump_hosts_dir" --output "$inventory_path"
 
   if [[ -n "$users_vars" && "$omit_users_vars" != "true" ]]; then
     extra+=(--extra-vars "@$users_vars")
@@ -137,7 +164,7 @@ run_ansible() {
 
   AWS_REGION="$aws_region" ansible-playbook \
     -i "$inventory_path" \
-    "ansible/playbooks/${playbook}" \
+    "${REPO_ROOT}/ansible/playbooks/${playbook}" \
     "${extra[@]}"
 }
 
@@ -185,10 +212,10 @@ case "$command_name" in
 
   apply)
     run_preflight
-    run_tg "$bootstrap_dir" apply -auto-approve
-    run_tg "$observability_dir" apply -auto-approve
-    run_tg "$endpoints_dir" apply -auto-approve
-    run_tg "$jump_hosts_dir" apply -auto-approve
+    run_tg_apply "$bootstrap_dir"
+    run_tg_apply "$observability_dir"
+    run_tg_apply "$endpoints_dir"
+    run_tg_apply "$jump_hosts_dir"
 
     run_ansible "jump_hosts.yml"
     ;;
@@ -205,12 +232,12 @@ case "$command_name" in
       echo "Skipping Ansible decommission hooks (no --users-vars provided)."
     fi
 
-    run_tg "$jump_hosts_dir" destroy -auto-approve
-    run_tg "$endpoints_dir" destroy -auto-approve
-    run_tg "$observability_dir" destroy -auto-approve
+    run_tg_destroy "$jump_hosts_dir"
+    run_tg_destroy "$endpoints_dir"
+    run_tg_destroy "$observability_dir"
 
     if [[ "$destroy_state" == "true" ]]; then
-      run_tg "$bootstrap_dir" destroy -auto-approve
+      run_tg_destroy "$bootstrap_dir"
     else
       echo "Skipping bootstrap-state destroy. Use --destroy-state to remove remote state bucket."
     fi

--- a/scripts/preflight_ssm_compliance.sh
+++ b/scripts/preflight_ssm_compliance.sh
@@ -74,4 +74,15 @@ if [[ "$cloudwatch_log_group" != "$expected_log_group" ]]; then
   exit 1
 fi
 
+# SSM can reference a log group name that does not exist yet; ensure the group is present in CloudWatch.
+log_group_match_count="$(aws logs describe-log-groups \
+  --region "$region" \
+  --log-group-name-prefix "$expected_log_group" \
+  --query "length(logGroups[?logGroupName=='${expected_log_group}'])" \
+  --output text)"
+if [[ "${log_group_match_count:-0}" != "1" ]]; then
+  echo "Non-compliant: CloudWatch log group '${expected_log_group}' not found (apply observability stack first)" >&2
+  exit 1
+fi
+
 echo "SSM preflight checks passed."

--- a/scripts/render_inventory.sh
+++ b/scripts/render_inventory.sh
@@ -56,22 +56,29 @@ fi
 
 mkdir -p "$(dirname "$output_path")"
 
-# When no state exists (e.g. after init but before apply), terragrunt output fails.
-# Use empty object so plan can complete; Ansible will run with zero hosts.
+# Fall back to an empty hosts map when there is no state yet or outputs are not populated, so `plan` can run
+# Ansible in check mode with zero hosts. Avoid matching English stderr from Terragrunt (locale/version drift).
+# If state has resources but `hosts` output is unreadable, treat that as an error.
 terragrunt_err_file="$(mktemp)"
-if ! hosts_json="$(terragrunt --working-dir "$terragrunt_dir" output -json hosts 2>"$terragrunt_err_file")"; then
-  if grep -qiE 'no outputs found|no state file|state does not exist' "$terragrunt_err_file"; then
-    # Expected case: no state / no outputs yet. Proceed with an empty inventory.
-    echo "Warning: terragrunt reported no state/outputs; proceeding with empty hosts inventory." >&2
-    hosts_json="{}"
-  else
-    echo "Error: failed to retrieve terragrunt hosts output:" >&2
-    cat "$terragrunt_err_file" >&2
-    rm -f "$terragrunt_err_file"
-    exit 1
-  fi
+state_list_file="$(mktemp)"
+if hosts_json="$(terragrunt --working-dir "$terragrunt_dir" output -json hosts 2>"$terragrunt_err_file")"; then
+  :
+elif all_json="$(terragrunt --working-dir "$terragrunt_dir" output -json 2>"$terragrunt_err_file")"; then
+  hosts_json="$(echo "$all_json" | jq -c '.hosts.value? // {}')"
+elif terragrunt --working-dir "$terragrunt_dir" state list >"$state_list_file" 2>>"$terragrunt_err_file" \
+  && [[ ! -s "$state_list_file" ]]; then
+  echo "Warning: Terraform state is empty or outputs missing in ${terragrunt_dir}; using empty hosts inventory." >&2
+  hosts_json="{}"
+elif ! terragrunt --working-dir "$terragrunt_dir" state list >/dev/null 2>>"$terragrunt_err_file"; then
+  echo "Warning: Terraform state not available in ${terragrunt_dir}; using empty hosts inventory." >&2
+  hosts_json="{}"
+else
+  echo "Error: state has resources but terragrunt outputs (hosts) could not be read:" >&2
+  cat "$terragrunt_err_file" >&2
+  rm -f "$terragrunt_err_file" "$state_list_file"
+  exit 1
 fi
-rm -f "$terragrunt_err_file"
+rm -f "$terragrunt_err_file" "$state_list_file"
 
 jq -n \
   --argjson hosts "$hosts_json" \

--- a/terragrunt/root.hcl
+++ b/terragrunt/root.hcl
@@ -12,16 +12,24 @@ locals {
   state_bucket     = local.account_config.locals.state_bucket
   is_bootstrap     = basename(get_terragrunt_dir()) == "bootstrap-state"
 
-  common_tags = {
-    Project        = "aws-jump-host"
-    Environment    = local.env
-    SubEnvironment = local.subenv
-    Region         = local.aws_region
-    ManagedBy      = "terragrunt"
-  }
+  # Base tags + optional extra_tags from live hierarchy (account → env → subenv; later wins on duplicate keys).
+  # The generated AWS provider uses default_tags with this map so taggable resources inherit it automatically;
+  # stacks also pass the same map into modules as common_tags / tags for explicit merges.
+  common_tags = merge(
+    {
+      Project        = "aws-jump-host"
+      Environment    = local.env
+      SubEnvironment = local.subenv
+      Region         = local.aws_region
+      ManagedBy      = "terragrunt"
+    },
+    lookup(local.account_config.locals, "extra_tags", {}),
+    lookup(local.env_config.locals, "extra_tags", {}),
+    lookup(local.subenv_config.locals, "extra_tags", {})
+  )
 }
 
-terraform_version_constraint = ">= 1.10"
+terraform_version_constraint = "~> 1.10"
 
 remote_state {
   backend      = "s3"

--- a/tests/ansible/inventory/localhost.yml
+++ b/tests/ansible/inventory/localhost.yml
@@ -1,0 +1,5 @@
+---
+all:
+  hosts:
+    localhost:
+      ansible_connection: local

--- a/tests/ansible/user_accounts_negative.yml
+++ b/tests/ansible/user_accounts_negative.yml
@@ -1,0 +1,26 @@
+---
+# Mirrors the restricted-admin guard in ansible/roles/user_accounts/tasks/main.yml (no become; no system changes).
+- name: user_accounts restricted admin guard (expect failure)
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars:
+    user_accounts_admin_use_unrestricted_sudo: false
+    user_accounts_admin_sudo_commands: []
+    user_accounts_users:
+      - username: badadmin
+        groups: [wheel]
+        sudo_profile: admin
+        state: present
+  tasks:
+    - name: Validate restricted admin sudo has a non-empty command list
+      ansible.builtin.assert:
+        that:
+          - user_accounts_admin_sudo_commands | length > 0
+        fail_msg: >-
+          user_accounts_admin_use_unrestricted_sudo is false but user_accounts_admin_sudo_commands is empty.
+          Define allowed commands (same pattern as ops) before using restricted admin.
+      when:
+        - not user_accounts_admin_use_unrestricted_sudo | default(true)
+        - (user_accounts_users | selectattr('sudo_profile', 'equalto', 'admin') | rejectattr('state', 'equalto', 'absent') | list | length) > 0

--- a/tests/ansible/user_accounts_smoke.yml
+++ b/tests/ansible/user_accounts_smoke.yml
@@ -1,0 +1,57 @@
+---
+# Renders user_accounts sudoers template to /tmp and asserts expected fragments (no visudo; no become).
+- name: Smoke test user_accounts sudoers template
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  become: false
+  vars:
+    user_accounts_admin_use_unrestricted_sudo: true
+    user_accounts_admin_sudo_commands: []
+    user_accounts_ops_sudo_commands:
+      - /usr/bin/systemctl --no-pager status *
+      - /usr/bin/journalctl --no-pager -u *
+    user_accounts_users:
+      - username: tadmin
+        groups: [wheel]
+        sudo_profile: admin
+      - username: tops
+        groups: [wheel]
+        sudo_profile: ops
+  tasks:
+    - name: Render sudoers fragments
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/../../ansible/roles/user_accounts/templates/sudoers.j2"
+        dest: "/tmp/jh-sudoers-smoke-{{ item.username }}"
+        mode: "0600"
+      loop: "{{ user_accounts_users | selectattr('sudo_profile', 'in', ['admin', 'ops']) | list }}"
+      loop_control:
+        label: "{{ item.username }}"
+
+    - name: Slurp admin fragment
+      ansible.builtin.slurp:
+        src: /tmp/jh-sudoers-smoke-tadmin
+      register: admin_frag
+
+    - name: Slurp ops fragment
+      ansible.builtin.slurp:
+        src: /tmp/jh-sudoers-smoke-tops
+      register: ops_frag
+
+    - name: Assert admin unrestricted sudo line
+      ansible.builtin.assert:
+        that:
+          - "'tadmin' in (admin_frag.content | b64decode)"
+          - "'NOPASSWD:ALL' in (admin_frag.content | b64decode)"
+
+    - name: Assert ops alias and journalctl allowlist
+      ansible.builtin.assert:
+        that:
+          - "'OPS_CMDS_TOPS' in (ops_frag.content | b64decode)"
+          - "'journalctl' in (ops_frag.content | b64decode)"
+
+    - name: Remove smoke fragments
+      ansible.builtin.file:
+        path: "/tmp/jh-sudoers-smoke-{{ item }}"
+        state: absent
+      loop: "{{ user_accounts_users | map(attribute='username') | list }}"

--- a/tests/contracts/check_deprecated_vars.sh
+++ b/tests/contracts/check_deprecated_vars.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fail() { echo "contract check failed: $*" >&2; exit 1; }
+
+# Deprecated YAML key (replaced by user_accounts_ops_sudo_commands); allow prose in docs without a defining colon.
+if grep -RIn --include='*.yml' --include='*.yaml' -e '^[[:space:]]*ops_sudo_commands[[:space:]]*:' \
+  "$root/ansible/playbooks" "$root/ansible/roles" "$root/ansible/group_vars" 2>/dev/null | grep -q .; then
+  fail "ops_sudo_commands: still used under ansible playbooks/roles/group_vars; use user_accounts_ops_sudo_commands"
+fi
+
+echo "deprecated vars contract OK"

--- a/tests/contracts/check_log_group.sh
+++ b/tests/contracts/check_log_group.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+orch="$root/scripts/orchestrate.sh"
+fail() { echo "contract check failed: $*" >&2; exit 1; }
+
+grep -q 'expected_log_group="/aws/ssm/jump-host/${env_name}/${subenv_name}/${aws_region}"' "$orch" \
+  || fail "orchestrate.sh expected_log_group pattern mismatch"
+
+# All example observability stacks must use the same interpolation shape as orchestrate.
+while IFS= read -r -d '' f; do
+  grep -q 'log_group_name = "/aws/ssm/jump-host/${include.root.locals.env}/${include.root.locals.subenv}/${include.root.locals.aws_region}"' "$f" \
+    || fail "observability log_group_name contract broken in $f"
+done < <(find "$root/examples/live" -path '*/observability/terragrunt.hcl' -print0)
+
+echo "log group naming contract OK"

--- a/tests/contracts/check_tool_pins.sh
+++ b/tests/contracts/check_tool_pins.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+versions="$root/.tool-versions"
+action="$root/.github/actions/ci-setup/action.yml"
+fail() { echo "contract check failed: $*" >&2; exit 1; }
+
+[[ -f "$versions" ]] || fail "missing .tool-versions"
+[[ -f "$action" ]] || fail "missing ci-setup action"
+
+tf_mise="$(awk '/^terraform[[:space:]]/ {print $2; exit}' "$versions")"
+tg_mise="$(awk '/^terragrunt[[:space:]]/ {print $2; exit}' "$versions")"
+[[ -n "$tf_mise" ]] || fail "terraform pin not found in .tool-versions"
+[[ -n "$tg_mise" ]] || fail "terragrunt pin not found in .tool-versions"
+
+tf_action="$(awk -F': ' '/terraform_version:/ {gsub(/["[:space:]]/, "", $2); print $2; exit}' "$action")"
+tg_action="$(awk -F': ' '/terragrunt-version:/ {gsub(/["[:space:]]/, "", $2); print $2; exit}' "$action")"
+[[ -n "$tf_action" ]] || fail "terraform_version not found in ci-setup"
+[[ -n "$tg_action" ]] || fail "terragrunt-version not found in ci-setup"
+
+[[ "$tf_mise" == "$tf_action" ]] || fail "Terraform pin mismatch: .tool-versions=$tf_mise ci-setup=$tf_action"
+[[ "$tg_mise" == "$tg_action" ]] || fail "Terragrunt pin mismatch: .tool-versions=$tg_mise ci-setup=$tg_action"
+
+echo "tool pin contract OK (terraform=$tf_mise terragrunt=$tg_mise)"

--- a/tests/policy/validate_ssm_policy.sh
+++ b/tests/policy/validate_ssm_policy.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+policy_file="${1:-}"
+if [[ -z "$policy_file" || ! -f "$policy_file" ]]; then
+  echo "usage: $0 <policy.json>" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+fail() {
+  echo "policy validation failed: $*" >&2
+  exit 1
+}
+
+jq -e . "$policy_file" >/dev/null || fail "invalid JSON"
+
+ver="$(jq -r '.Version // empty' "$policy_file")"
+[[ "$ver" == "2012-10-17" ]] || fail "expected Version 2012-10-17, got '$ver'"
+
+# Exactly one StartSession statement with instance + managed-instance resources and StringEquals AccessProfile (no ForAnyValue on that key).
+start_count="$(jq '[.Statement[] | select(.Action == "ssm:StartSession" or .Action == ["ssm:StartSession"])] | length' "$policy_file")"
+[[ "$start_count" -eq 1 ]] || fail "expected exactly one StartSession statement, found $start_count"
+
+has_for_any="$(jq '[.. | objects | select(has("ForAnyValue:StringEquals")) | .["ForAnyValue:StringEquals"] | keys[]?] | map(select(. == "ssm:resourceTag/AccessProfile")) | length' "$policy_file")"
+[[ "$has_for_any" -eq 0 ]] || fail "ForAnyValue:StringEquals must not be used for ssm:resourceTag/AccessProfile"
+
+access_cond="$(jq -r '.Statement[] | select(.Action == "ssm:StartSession") | .Condition.StringEquals["ssm:resourceTag/AccessProfile"] // empty' "$policy_file")"
+[[ -n "$access_cond" ]] || fail "StartSession must use Condition.StringEquals ssm:resourceTag/AccessProfile"
+[[ "$access_cond" == *'PrincipalTag/AccessProfile'* ]] || fail "AccessProfile condition should reference aws:PrincipalTag/AccessProfile"
+
+resume_count="$(jq '[.Statement[] | select((.Action | type == "array") and ((.Action | index("ssm:ResumeSession")) != null))] | length' "$policy_file")"
+[[ "$resume_count" -eq 1 ]] || fail "expected one ResumeSession/TerminateSession statement"
+
+resume_on_session="$(jq -r '.Statement[] | select((.Action | type == "array") and ((.Action | index("ssm:ResumeSession")) != null)) | .Resource // empty' "$policy_file")"
+jq -n --arg r "$resume_on_session" --arg n 'session/${aws:username}-' -e '($r | index($n) != null)' >/dev/null \
+  || fail "Resume/Terminate should be scoped to session ARN pattern (got: $resume_on_session)"
+
+echo "policy OK: $policy_file"

--- a/tests/shell/bin/terragrunt
+++ b/tests/shell/bin/terragrunt
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Fake terragrunt for shell tests; behavior controlled by FAKE_TG_SCENARIO.
+set -euo pipefail
+
+if [[ -n "${FAKE_TG_LOG:-}" ]]; then
+  printf '%q ' "$@" >>"$FAKE_TG_LOG"
+  echo >>"$FAKE_TG_LOG"
+fi
+
+args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --working-dir) shift 2 ;;
+    *) args+=("$1"); shift ;;
+  esac
+done
+set -- "${args[@]}"
+
+scenario="${FAKE_TG_SCENARIO:-hosts_ok}"
+
+if [[ "${1:-}" == output && "${2:-}" == -json ]]; then
+  if [[ "${3:-}" == hosts ]]; then
+    if [[ "$scenario" == "hosts_ok" ]]; then
+      jq -n -c '{ "core-01": { instance_id: "i-abc", private_ip: "10.0.0.5", access_profile: "ops" } }'
+      exit 0
+    fi
+    echo "fake: output -json hosts unavailable" >&2
+    exit 1
+  fi
+  if [[ "$scenario" == "via_all_json" ]]; then
+    jq -n -c '{ hosts: { value: { "h1": { instance_id: "i-h1", private_ip: "10.0.1.1", access_profile: "admin" } } } }'
+    exit 0
+  fi
+  echo "fake: output -json unavailable" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == state && "${2:-}" == list ]]; then
+  case "$scenario" in
+    empty_state)
+      exit 0
+      ;;
+    no_state)
+      echo "fake: no state backend" >&2
+      exit 1
+      ;;
+    stale_state)
+      echo "aws_instance.jump_host"
+      exit 0
+      ;;
+    *)
+      echo "fake: state list unexpected for scenario=$scenario" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ "${1:-}" =~ ^(plan|init|apply|destroy)$ ]]; then
+  exit 0
+fi
+
+echo "fake terragrunt: unhandled: $*" >&2
+exit 99

--- a/tests/shell/helper.bash
+++ b/tests/shell/helper.bash
@@ -1,0 +1,7 @@
+# Shared setup for Bats: repo root, fake terragrunt on PATH.
+setup() {
+  export REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+  cd "$REPO_ROOT" || exit 1
+  export PATH="${BATS_TEST_DIRNAME}/bin:${PATH}"
+  unset FAKE_TG_LOG || true
+}

--- a/tests/shell/orchestrate.bats
+++ b/tests/shell/orchestrate.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+load helper
+
+@test "orchestrate exits non-zero with no arguments" {
+  run ./scripts/orchestrate.sh
+  [[ "$status" -ne 0 ]]
+}
+
+@test "orchestrate rejects unknown arguments" {
+  run ./scripts/orchestrate.sh plan --live-dir ./examples/live --env dev --subenv east --region us-east-1 --not-a-real-flag
+  [[ "$status" -ne 0 ]]
+}
+
+@test "orchestrate requires existing live stack directories" {
+  run ./scripts/orchestrate.sh plan --live-dir /nonexistent/path --env dev --subenv east --region us-east-1
+  [[ "$status" -ne 0 ]]
+}
+
+@test "orchestrate destroy passes -auto-approve to terragrunt when --auto-approve set" {
+  export SKIP_PREFLIGHT=true
+  export FAKE_TG_SCENARIO=hosts_ok
+  local log
+  log="$(mktemp)"
+  export FAKE_TG_LOG="$log"
+  run ./scripts/orchestrate.sh destroy \
+    --live-dir ./examples/live \
+    --env dev \
+    --subenv east \
+    --region us-east-1 \
+    --auto-approve
+  [[ "$status" -eq 0 ]]
+  grep -q -- '-auto-approve' "$log" || grep -q -- 'auto-approve' "$log"
+  rm -f "$log"
+}
+
+@test "orchestrate destroy without --auto-approve does not add -auto-approve" {
+  export SKIP_PREFLIGHT=true
+  export FAKE_TG_SCENARIO=hosts_ok
+  local log
+  log="$(mktemp)"
+  export FAKE_TG_LOG="$log"
+  run ./scripts/orchestrate.sh destroy \
+    --live-dir ./examples/live \
+    --env dev \
+    --subenv east \
+    --region us-east-1
+  [[ "$status" -eq 0 ]]
+  run grep -qF 'destroy -auto-approve' "$log"
+  [[ "$status" -ne 0 ]]
+  rm -f "$log"
+}

--- a/tests/shell/render_inventory.bats
+++ b/tests/shell/render_inventory.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+load helper
+
+@test "render_inventory maps hosts from output -json hosts" {
+  export FAKE_TG_SCENARIO=hosts_ok
+  local out
+  out="$(mktemp)"
+  run ./scripts/render_inventory.sh \
+    --terragrunt-dir "$REPO_ROOT/examples/live/dev/east/us-east-1/jump-hosts" \
+    --output "$out"
+  [[ "$status" -eq 0 ]]
+  run jq -e '.all.children.jump_hosts.hosts["i-abc"].host_name == "core-01" and .all.children.jump_hosts.hosts["i-abc"].access_profile == "ops"' "$out"
+  [[ "$status" -eq 0 ]]
+  rm -f "$out"
+}
+
+@test "render_inventory falls back to hosts from full output -json" {
+  export FAKE_TG_SCENARIO=via_all_json
+  local out
+  out="$(mktemp)"
+  run ./scripts/render_inventory.sh \
+    --terragrunt-dir "$REPO_ROOT/examples/live/dev/east/us-east-1/jump-hosts" \
+    --output "$out"
+  [[ "$status" -eq 0 ]]
+  run jq -e '.all.children.jump_hosts.hosts["i-h1"].host_name == "h1"' "$out"
+  [[ "$status" -eq 0 ]]
+  rm -f "$out"
+}
+
+@test "render_inventory uses empty inventory when state is empty" {
+  export FAKE_TG_SCENARIO=empty_state
+  local out
+  out="$(mktemp)"
+  run ./scripts/render_inventory.sh \
+    --terragrunt-dir "$REPO_ROOT/examples/live/dev/east/us-east-1/jump-hosts" \
+    --output "$out"
+  [[ "$status" -eq 0 ]]
+  run jq -e '.all.children.jump_hosts.hosts | length == 0' "$out"
+  [[ "$status" -eq 0 ]]
+  rm -f "$out"
+}
+
+@test "render_inventory uses empty inventory when state is unavailable" {
+  export FAKE_TG_SCENARIO=no_state
+  local out
+  out="$(mktemp)"
+  run ./scripts/render_inventory.sh \
+    --terragrunt-dir "$REPO_ROOT/examples/live/dev/east/us-east-1/jump-hosts" \
+    --output "$out"
+  [[ "$status" -eq 0 ]]
+  run jq -e '.all.children.jump_hosts.hosts | length == 0' "$out"
+  [[ "$status" -eq 0 ]]
+  rm -f "$out"
+}
+
+@test "render_inventory fails when state has resources but hosts output is missing" {
+  export FAKE_TG_SCENARIO=stale_state
+  local out
+  out="$(mktemp)"
+  run ./scripts/render_inventory.sh \
+    --terragrunt-dir "$REPO_ROOT/examples/live/dev/east/us-east-1/jump-hosts" \
+    --output "$out"
+  [[ "$status" -ne 0 ]]
+  rm -f "$out"
+}


### PR DESCRIPTION
## Summary

Consolidated **security**, **operational safety**, and **CI quality** improvements: tighter IAM/SSM policy examples, Ansible sudo and account handling, shared CI tooling with pinned third-party binaries, automated tests, Terragrunt-wide tag propagation, Terraform **1.10** / AWS provider **6.x** alignment, and safer orchestration defaults (interactive Terraform unless `--auto-approve`).

## Security and IAM

- **`policy-templates/ssm-access-example.json`**: Restrict **StartSession** to tagged instances with `StringEquals` on `AccessProfile`; move **ResumeSession** / **TerminateSession** to a separate statement on session ARNs. Reduces accidental broad matching with multi-value tags.
- **`policy-templates/README.md`** and **`docs/security-user-prerequisites.md`**: Document ABAC pitfalls, session ARN scoping, and validation expectations.

## Ansible

- **`user_accounts_ops_sudo_commands`** (replaces deprecated `ops_sudo_commands` wiring in playbooks); narrower **journalctl** sudo patterns.
- Optional **restricted admin** sudo via `user_accounts_admin_use_unrestricted_sudo` / `user_accounts_admin_sudo_commands`.
- Lock password for **`ssm-user`** when present.
- **`tests/ansible/`**: localhost smoke and negative tests for the role.

## Terraform and Terragrunt

- Modules: **`required_version = "~> 1.10"`**, **`hashicorp/aws ~> 6.0`**; replace deprecated **`data.aws_region.current.name`** with **`.id`** where needed.
- **`terragrunt/root.hcl`**: Merge optional **`extra_tags`** from `account.hcl` / `env.hcl` / `subenv.hcl` into **`common_tags`**; provider **`default_tags`** plus existing stack merges.
- **`modules/terraform/observability`**: Optional metric filter and alarm hooks (default off) for future paging.

## Scripts and orchestration

- **`scripts/orchestrate.sh`**: **`--auto-approve`** for non-interactive apply/destroy; paths rooted at repo root for inventory and playbooks.
- **`scripts/preflight_ssm_compliance.sh`**: Ensure the expected session log group exists in CloudWatch.
- **`scripts/render_inventory.sh`**: More reliable handling when Terragrunt state or outputs are missing.

## CI and tests

- **`.github/actions/ci-setup`**: Single composite action (Terraform, Terragrunt, TFLint, Python tools, **tfsec** with checksum, shellcheck, jq, bats, Ansible collections).
- **`make test`**: Policy checks, repo contracts (log group naming, tool pins, deprecated vars), **bats** for shell scripts, Ansible tests.
- **`.github/workflows/aws-plan-optional.yml`**: Manual optional Terragrunt **plan** against example live config when **`AWS_PLAN_TEST_ROLE_ARN`** is set (stays green without AWS).

## Documentation and examples

- **`docs/consumer-guide.md`**: Global tags, apply/destroy behavior, ops sudo variable rename.
- **`docs/architecture.md`**: Single-AZ example tradeoff; observability hooks mention.
- **`examples/live`**: Account `extra_tags` comment; README orchestration notes.

## How to verify locally

- `make fmt-check && make lint && make validate`
- `make test`
- Optional: `mise exec -- terragrunt render` from an example stack directory to confirm resolved config.

## Merge notes

- Consumers who used **`ops_sudo_commands`** in external vars should switch to **`user_accounts_ops_sudo_commands`** (see consumer guide).
- **`apply` / `destroy`** are interactive by default; automation should use **`--auto-approve`** or **`make apply-example-auto` / `make destroy-example-auto`**.
