### PR TITLE
fix(ci): update reusable workflow refs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,4 +11,4 @@ permissions:
 
 jobs:
   quality:
-    uses: benvon/reusable-workflows/.github/workflows/aws-infra-quality.yml@0a878c63c5a17372ecd27a1fd1fffd7c1b88e5d3
+    uses: benvon/reusable-workflows/.github/workflows/aws-infra-quality.yml@f70796de0a6527dbed267a64835c3cc81b8144e0


### PR DESCRIPTION
## Summary
Bump this repo's reusable workflow references to benvon/reusable-workflows commit f70796de0a6527dbed267a64835c3cc81b8144e0.

## Why
This shared workflow revision includes the workflow permissions fix in release-policy and keeps the repo aligned on one reusable workflow commit.

## Validation
- Verified the updated workflow refs in the repo.
- Verified the git commit is signed.